### PR TITLE
Make SMBus argument optional in constructor

### DIFF
--- a/sensorhub/hub.py
+++ b/sensorhub/hub.py
@@ -31,7 +31,7 @@ class StatusRegisterErrorCode(Enum):
 class SensorHub:
     _bus: SMBus
 
-    def __init__(self, system_management_bus: SMBus):
+    def __init__(self, system_management_bus: SMBus = None):
         self._bus = system_management_bus or SMBus(DEVICE_BUS)
 
     def _read_sensor_board_register(self, buffer: SensorRegister) -> int:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="sensorhub",
-    version="2.0.0",
+    version="2.0.1",
     author="Merlin Gough",
     author_email="goughmerlin@gmail.com",
     description="A simple library to use with the DockerPi SensorHub (EP-0106)",

--- a/test/test_hub.py
+++ b/test/test_hub.py
@@ -1,9 +1,9 @@
 from pytest import fixture, raises, mark
-from unittest.mock import call, Mock
+from unittest.mock import call, Mock, patch
 
 from smbus2 import SMBus
 
-from sensorhub.hub import SensorHub, SensorRegister
+from sensorhub.hub import SensorHub, SensorRegister, DEVICE_BUS
 
 
 @fixture
@@ -216,3 +216,12 @@ def test_barometer_pressure_returns_expected_reading(sensor_hub, bus, device_add
         call(device_address, SensorRegister.BAROMETRIC_PRESSURE_MIDDLE.value),
         call(device_address, SensorRegister.BAROMETRIC_PRESSURE_HIGH.value)
     ])
+
+
+@patch("sensorhub.hub.SMBus", autospec=True)
+def test_can_be_created_with_default_smbus(sm_bus):
+    hub = SensorHub()
+
+    assert hub._bus == sm_bus.return_value
+    sm_bus.assert_called_once_with(DEVICE_BUS)
+


### PR DESCRIPTION
Silly oversight, we have the functionality to create a default SMBus, but it was difficult to use as the argument was required.

Closes #3 